### PR TITLE
MOD: 正常处理 cookie 的导出和导入

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -10,7 +10,7 @@ from config import config
 def prepare_crawler(args):
     from crawl.crawler import Crawler
 
-    config.crawler = Crawler(args.email, args.password)
+    config.crawler = Crawler(args.email, args.password, Crawler.load_cookie())
 
     return config.crawler
 


### PR DESCRIPTION
人人的 Cookie 有 for 参数，如果用 requests.utils.dict_from_cookiejar 会
导致信息丢失，从而读进来的不能用，会触发重登陆

放弃用 json 格式，改用 pickle 做二进制读写，且不做 dict/cookiejar 转换