### PR TITLE
fix zero pic album issue and connection timeout issue

### DIFF
--- a/crawl/album.py
+++ b/crawl/album.py
@@ -15,7 +15,11 @@ crawler = config.crawler
 
 def get_album_summary(album_id, uid=crawler.uid):
     resp = crawler.get_url(config.ALBUM_SUMMARY_URL.format(uid=uid, album_id=album_id))
-    first_photo_id = re.findall(r'"photoId":"(\d+)",', resp.text)[0]
+    find_photo_ids = re.findall(r'"photoId":"(\d+)",', resp.text)
+    if len(find_photo_ids) == 0:
+        return 0
+    else:
+        first_photo_id = re.findall(r'"photoId":"(\d+)",', resp.text)[0]
 
     layer = crawler.get_json(config.PHOTO_INFO_URL.format(uid=uid, photo_id=first_photo_id))
 

--- a/crawl/crawler.py
+++ b/crawl/crawler.py
@@ -9,7 +9,7 @@ import webbrowser
 
 import requests
 import requests.utils
-from requests.exceptions import ConnectionError  # pylint: disable=W0622
+from requests.exceptions import ConnectionError, Timeout  # pylint: disable=W0622
 
 from config import config
 
@@ -91,7 +91,7 @@ class Crawler(object):
                 resp = self.session.post(**request_args)
             else:
                 resp = self.session.get(**request_args)
-        except ConnectionError:
+        except (ConnectionError, Timeout) as e:
             retry += 1
             time.sleep(retry)
             return self.get_url(url, params, method, retry)


### PR DESCRIPTION
If there was no photo in the album, the re.findall()[0] in album.py will raise IndexError
For crawler.py, previously it only capture ConnectionError. However, ReadTimeout can also happen. Now Timeout was added to the exception handler to retry the request.