### PR TITLE
FIX people comments on gossips with no tinyUrl

### DIFF
--- a/crawl/crawler.py
+++ b/crawl/crawler.py
@@ -111,7 +111,7 @@ class Crawler(object):
             params = dict()
 
         resp = self.get_url(url, params, method)
-        r = json.loads(resp.text)
+        r = json.loads(resp.text.replace(',}','}'))
 
         if int(r.get('code', 0)):
             if retry >= config.RETRY_TIMES:

--- a/crawl/gossip.py
+++ b/crawl/gossip.py
@@ -24,7 +24,10 @@ def load_gossip_page(page, uid=crawler.uid):
     r = crawler.get_json(config.GOSSIP_URL, params=param, method='POST')
 
     for c in r['array']:
-        local_pic = get_image(c['tinyUrl'])
+        if 'tinyUrl' in c:
+            local_pic = get_image(c['tinyUrl'])
+        else:
+            local_pic = '/static/men_tiny.gif'
 
         gossip = {
             'id': c['id'],


### PR DESCRIPTION
some people don't have tinyUrl. This lead to 2 problems
1, the json from renren is broken (with illegal isolated comma), need to fix that. ',}'->'}'
2, they don't have tinyUrl, we need to use the default figure