### PR TITLE
FIX ill formated image URL

### DIFF
--- a/crawl/utils.py
+++ b/crawl/utils.py
@@ -15,6 +15,12 @@ def get_image(img_url):
     if not img_url:
         return ''
 
+    last_loc_http = img_url.rfind('http:')
+    # when there are more than one occurences of http:
+    # We will crop the str and leave the last one
+    if last_loc_http > 0:
+        img_url = img_url[last_loc_http:]
+
     path = img_url.split('/')
     path[0] = 'static'
     path[1] = 'img'


### PR DESCRIPTION
Some old users have ill formated head pic url in the json.
Example:
http://head.xiaonei.com/photos/http://hd29.xiaonei.com/photos/hd29/20080823/xx/xx/tiny_xxx.jpg
This patch will search for the last occurence of "http:" and crop out the correct URL.