### PR TITLE
Revert "Fixed exported album links"

### DIFF
--- a/export.py
+++ b/export.py
@@ -18,10 +18,6 @@ logger = logging.getLogger(__name__)
 
 abs_pattern = r'(src|href)="(\s*)/(.*?)(\s*)"'
 abs_replace = r'\1="{rel_path}/\3"'
-uid_pattern = r'<a(.*?)href="({rel_path}.*?)(\?uid=\d+)"'
-uid_replace = r'<a\1href="\2"'
-album_pattern = r'<a(.*?)href="({rel_path}.*?)/album/(\d+)"'
-album_replace = r'<a\1href="\2/album/\3/page/1"'
 html_pattern = r'<a(.*?)href="({rel_path}.*?)"'
 html_replace = r'<a\1href="\2.html"'
 
@@ -36,10 +32,6 @@ def get_json(client, url_path):
 
 def trans_relative_path(content, rel_path):
     content = re.sub(abs_pattern, abs_replace.format(rel_path=rel_path), content,
-                     flags=re.M | re.DOTALL)
-    content = re.sub(uid_pattern.format(rel_path=rel_path), uid_replace, content,
-                     flags=re.M | re.DOTALL)
-    content = re.sub(album_pattern.format(rel_path=rel_path), album_replace, content,
                      flags=re.M | re.DOTALL)
     content = re.sub(html_pattern.format(rel_path=rel_path), html_replace, content,
                      flags=re.M | re.DOTALL)


### PR DESCRIPTION
Reverts whusnoopy/renrenBackup#12

1. too wild re pattern make export too slow, and uncontrolled
2. `uid_pattern` won't appear in html files generated by this project, all url rules defined in flask contains uid in url path part, not in search part
3. `album_pattern` used to solve the album entry, the better way is change entry to the first page of album in flask