### PR TITLE
非中文系统下 logger 报错 UnicodeEncodeError

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,7 +27,8 @@ class LocalConfig(object):
                 'class': 'logging.handlers.WatchedFileHandler',
                 'level': 'DEBUG',
                 'formatter': 'file',
-                'filename': 'log/renrenBackup.log'
+                'filename': 'log/renrenBackup.log',
+                'encoding': 'utf-8'
             }
         },
         'loggers': {


### PR DESCRIPTION
## 当前 Pull Request 要解决的问题

在抓取时大量报错，怀疑原因是我的系统语言非中文

## 问题举例

在使用logger时，如果内容包含中文，就会输出以下错误
```
--- Logging error ---
Traceback (most recent call last):
  File "C:\Python37\lib\logging\__init__.py", line 1037, in emit
    stream.write(msg + self.terminator)
  File "C:\Python37\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 30-34: character maps to <undefined>
```

## 改动逻辑

在 `LOGGING_CONF` 中加入 `encoding` 参数。（根据https://docs.python.org/3/library/logging.handlers.html#filehandler）

## 新引入的依赖（如有）

无
