### PR TITLE
相册图片详情页显示图片大小适应页面

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -153,3 +153,25 @@ img.gossip-gift {
 .sr-only {
     display: none;
 }
+
+.photo-container {
+    height: 0;
+    padding-bottom: 75%;
+    position: relative;
+    overflow: hidden;
+}
+
+.photo-container .photo-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.photo-container .ui.image {
+    max-height: 100%;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/templates/photo.html
+++ b/templates/photo.html
@@ -13,7 +13,9 @@
 <div class="ui divider"></div>
 
 <div class="ui segment">
-    <img class="ui centered image" src="{{ photo.src }}">
+    <a href="{{ photo.src }}" target="_blank">
+        <img class="ui centered image" src="{{ photo.src }}">
+    </a>
     <div class="ui divider"></div>
     <p>
         {{ photo.title|safe }}

--- a/templates/photo.html
+++ b/templates/photo.html
@@ -13,9 +13,11 @@
 <div class="ui divider"></div>
 
 <div class="ui segment">
-    <a href="{{ photo.src }}" target="_blank">
-        <img class="ui centered image" src="{{ photo.src }}">
-    </a>
+    <div class="photo-container">
+        <a class="photo-link" href="{{ photo.src }}" target="_blank">
+            <img class="ui centered image" src="{{ photo.src }}">
+        </a>
+    </div>
     <div class="ui divider"></div>
     <p>
         {{ photo.title|safe }}


### PR DESCRIPTION
## 当前 Pull Request 要解决的问题

相册图片详情页显示图片大小适应页面 #39 

## 问题举例

图片详情页在遇到特别高的图片时，之前会撑开非常高，期望控制下最大高度。同时支持点击图片查看原图，这样也不会因为被限制了大小而看不到细节

## 改动逻辑

对于图片详情页的图片外部加一个宽高比为 4:3 且自适应宽度的容器，然后将图片在里面居中显示并控制最大高度（最大宽度在 semantic ui 里已经默认限制了）。图片 `<img>` 标签外套一个 `<a>` 标签新开 Tab 打开原图

## 新引入的依赖（如有）

无
